### PR TITLE
fix(infra): repair dev healthcheck, smoke, console env and tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,19 +129,19 @@ db-reset: down ## Destroy and rebuild database
 ##—————— ✅ Tests ——————
 test: ## Run all PHPUnit tests (fail-fast)
 	@echo "$(GREEN)Running all tests...$(RESET)"
-	$(DC) exec $(DC_APP) ./vendor/bin/phpunit --fail-fast
+	$(DC) exec $(DC_APP) ./vendor/bin/phpunit --stop-on-failure
 
 test-unit: ## Run unit tests only (#[Group('unit')])
 	@echo "$(GREEN)Running unit tests...$(RESET)"
-	$(DC) exec $(DC_APP) ./vendor/bin/phpunit --group=unit --fail-fast
+	$(DC) exec $(DC_APP) ./vendor/bin/phpunit --group=unit --stop-on-failure
 
 test-integration: ## Run integration tests only (#[Group('integration')])
 	@echo "$(GREEN)Running integration tests...$(RESET)"
-	$(DC) exec $(DC_APP) ./vendor/bin/phpunit --group=integration --fail-fast
+	$(DC) exec $(DC_APP) ./vendor/bin/phpunit --group=integration --stop-on-failure
 
 test-e2e: ## Run API/E2E tests only (#[Group('e2e')])
 	@echo "$(GREEN)Running E2E tests...$(RESET)"
-	$(DC) exec $(DC_APP) ./vendor/bin/phpunit --group=e2e --fail-fast
+	$(DC) exec $(DC_APP) ./vendor/bin/phpunit --group=e2e --stop-on-failure
 
 test-coverage: ## Run tests with text coverage report
 	@echo "$(GREEN)Running tests with coverage...$(RESET)"
@@ -172,8 +172,8 @@ ci: lint-check analyze test ## Simulate CI pipeline (no auto-fix)
 
 smoke: ## End-to-end smoke check (console boots, /healthz responds)
 	@echo "$(YELLOW)Running smoke check...$(RESET)"
-	$(DC) exec $(DC_APP) bin/console list >/dev/null
-	@curl -fsS http://localhost:$${HTTP_PORT:-8750}/healthz | tee /dev/stderr | grep -q '"ok":true'
+	$(DC) exec -T $(DC_APP) bin/console list >/dev/null
+	@$(DC) exec -T $(DC_APP) sh -c 'curl -fsS -k --resolve $$SERVER_NAME:443:127.0.0.1 https://$$SERVER_NAME/healthz' | tee /dev/stderr | grep -q '"ok":true'
 	@echo "$(GREEN)Smoke check passed!$(RESET)"
 
 docs-check: ## Lint ADR front-matter and AGENTS.md token budget

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,11 @@ services:
       DATABASE_URL: "postgres://user:password@db:5432/app_db?serverVersion=17&charset=utf8"
       REDIS_URL: "redis://redis:6379"
       MESSENGER_TRANSPORT_DSN: "redis://redis:6379/messages"
+      # bin/console reads only the real process env (no Dotenv), so config-required
+      # vars must be passed explicitly. Mercure values come from .env.
+      MERCURE_URL: "${MERCURE_URL}"
+      MERCURE_PUBLIC_URL: "${MERCURE_PUBLIC_URL}"
+      MERCURE_JWT_SECRET: "${MERCURE_JWT_SECRET}"
       PHP_INI_SCAN_DIR: ":/usr/local/etc/php/conf.d"
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
       XDEBUG_CLIENT_HOST: "host.docker.internal"
@@ -47,7 +52,9 @@ services:
       redis:
         condition: service_started
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost/healthz"]
+      # Caddy auto-redirects HTTP->HTTPS on SERVER_NAME, so probe HTTPS directly.
+      # --resolve pins the cert hostname to the loopback the container listens on.
+      test: ["CMD-SHELL", "curl -fsS -k --resolve ${SERVER_NAME}:443:127.0.0.1 https://${SERVER_NAME}/healthz"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -66,7 +73,7 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U user -d app_db"]
       interval: 10s
@@ -82,7 +89,7 @@ services:
     volumes:
       - redis_data:/data
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s

--- a/pint.json
+++ b/pint.json
@@ -13,5 +13,8 @@
         "node_modules",
         "coverage",
         "var"
+    ],
+    "notPath": [
+        "config/reference.php"
     ]
 }


### PR DESCRIPTION
Fixes a cluster of dev-stack issues that surface on any project with FrankenPHP auto-HTTPS enabled (i.e. `SERVER_NAME` set). All were reproduced on a fresh checkout.

## What was broken

| Area | Symptom | Fix |
|---|---|---|
| compose healthcheck | `wget http://localhost/healthz` → Caddy 308 to HTTPS on `SERVER_NAME` → cert host mismatch → container **`unhealthy`** forever | probe HTTPS with `curl -fsS -k --resolve ${SERVER_NAME}:443:127.0.0.1 …` |
| `make smoke` | same redirect; also defaulted to wrong port | run the probe **inside** the container against `$SERVER_NAME` |
| console env | `bin/console` has a custom bootstrap without `Dotenv::bootEnv`, so it reads only the real process env. `MERCURE_*` weren't in compose `environment` → `Environment variable not found: MERCURE_URL` on any console command | pass `MERCURE_*` through compose `environment` (mirrors the CI workflow) |
| `make test*` | `phpunit --fail-fast` — not a PHPUnit 11 option | `--stop-on-failure` |
| db/redis ports | hardcoded `5432:5432` / `6379:6379` blocks running multiple franken projects side by side | `${DB_PORT:-5432}` / `${REDIS_PORT:-6379}` (defaults unchanged) |
| Pint | linted the auto-generated, gitignored `config/reference.php` → local `make check`/`ci` fail once it's generated (CI never generates it) | `notPath: ["config/reference.php"]` |

## Notes

- Behaviour with defaults is unchanged (ports still 5432/6379 unless overridden).
- Optionally `.env.dist` could document `DB_PORT`/`REDIS_PORT`; left out to keep this minimal.

Found while bootstrapping a downstream project on this skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)