### PR TITLE
fix(infra): honour --env in bin/console and isolate the test database

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -18,6 +18,32 @@ if (PHP_VERSION_ID < 80500) {
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-$kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', (bool) ($_SERVER['APP_DEBUG'] ?? true));
+$env = $_SERVER['APP_ENV'] ?? 'dev';
+$debug = (bool) ($_SERVER['APP_DEBUG'] ?? true);
+
+// The Kernel environment is fixed at construction — before the Console
+// Application parses options — so honour --env/-e and --no-debug straight from
+// argv (mirrors what the Symfony Runtime does for the HTTP entrypoint).
+$argv = $_SERVER['argv'] ?? [];
+if (is_array($argv)) {
+    foreach ($argv as $i => $arg) {
+        if (!is_string($arg)) {
+            continue;
+        }
+
+        if ($arg === '--env' || $arg === '-e') {
+            $next = $argv[$i + 1] ?? null;
+            $env = is_string($next) ? $next : $env;
+        } elseif (str_starts_with($arg, '--env=')) {
+            $env = substr($arg, 6);
+        } elseif (str_starts_with($arg, '-e') && strlen($arg) > 2) {
+            $env = substr($arg, 2);
+        } elseif ($arg === '--no-debug') {
+            $debug = false;
+        }
+    }
+}
+
+$kernel = new Kernel($env, $debug);
 $application = new Application($kernel);
 $application->run();

--- a/config/packages/test/doctrine.yaml
+++ b/config/packages/test/doctrine.yaml
@@ -1,0 +1,6 @@
+doctrine:
+    dbal:
+        # Run tests against a separate database (e.g. app -> app_test) so they never
+        # touch the dev/runtime DB. Foundry's ResetDatabase recreates the schema, and
+        # without this the runtime DATABASE_URL (the dev DB) would be wiped.
+        dbname_suffix: _test


### PR DESCRIPTION
Two footguns found while building a downstream project on the skeleton.

## 1. `bin/console` ignores `--env` / `-e`

The Kernel env was fixed to `$_SERVER['APP_ENV'] ?? 'dev'` and the CLI flags were never read. Because the bootstrap doesn't go through the Symfony Runtime (no Dotenv by design), `bin/console <cmd> --env=test` silently ran in the ambient env — in Docker that's `dev` (`ENV APP_ENV=dev`). So `--env=test` was a no-op locally, which is surprising and bites anything env-specific (e.g. preparing the test DB).

**Fix:** parse `--env`/`-e` and `--no-debug` from `argv` before constructing the Kernel, mirroring what the Runtime does for the HTTP entrypoint. Type-safe; `bin/` isn't in the PHPStan paths but the code guards `is_array`/`is_string` anyway.

## 2. Tests run against the dev/runtime database

`.env.test` ships a sqlite `DATABASE_URL`, but it's shadowed by the real `DATABASE_URL` from the container/CI env — so `make test` runs against the **runtime** DB, and Foundry's `ResetDatabase` wipes it.

**Fix:** add `config/packages/test/doctrine.yaml` with `dbname_suffix: _test`, so tests use a separate database (e.g. `app` → `app_test`) regardless of host/credentials.

Both changes keep defaults intact and don't introduce Dotenv (skeleton stays HTML-first / env-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)