### PR TITLE
feat(dev): auto-restart FrankenPHP workers on source changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help shell e d install env-create composer-install \
-        up run down build rebuild ps logs composer-chown \
+        up run down restart build rebuild ps logs composer-chown \
         db-migrate db-rollback db-seed db-console db-fresh db-reset test-db \
         test test-unit test-integration test-e2e test-coverage coverage-html \
         lint lint-check analyze check ci smoke docs-check \
@@ -78,6 +78,8 @@ down: ## Stop and remove containers
 	$(DC) down --remove-orphans
 
 d: down
+
+restart: down up ## Restart containers (down + up; recreates so compose/Caddy config changes apply)
 
 logs: ## Follow container logs
 	@echo "$(YELLOW)Showing and following logs...$(RESET)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,22 @@ services:
       # (DATABASE_URL, APP_SECRET, …) is NOT duplicated here — Symfony reads it
       # from the mounted .env via symfony/dotenv. Single source of truth.
       SERVER_NAME: "${SERVER_NAME:-localhost}"
-      FRANKENPHP_CONFIG: "worker ./public/index.php"
+      # Dev runs the worker in block form to enable file-watching: worker mode
+      # keeps PHP resident, so source edits aren't visible until the workers
+      # restart — `watch` restarts them on change. Scoped to the dirs a restart
+      # actually needs (PHP + compiled container config); the default glob
+      # (./**/*.{env,php,twig,yaml,yml}) would also match var/cache/*.php, which
+      # Symfony rewrites every request → a restart loop. Twig is left out: dev
+      # recompiles templates lazily, no worker restart needed. Prod overrides
+      # this with a plain single-line worker (docker/compose.prod.yml).
+      FRANKENPHP_CONFIG: |
+        worker {
+          file ./public/index.php
+          watch ./src/**/*.php
+          watch ./config/**/*.{php,yaml,yml}
+          watch ./public/index.php
+          watch ./.env
+        }
       # admin on :2019 (not localhost-only) so the optional prometheus service
       # can scrape /metrics over the compose network; the port stays unpublished.
       CADDY_GLOBAL_OPTIONS: |


### PR DESCRIPTION
Worker mode keeps PHP resident, so `src`/`config` edits weren't visible until a manual restart. FrankenPHP's `watch` now restarts the workers on change, scoped to `src`, `config` and `.env` — the default glob also matches `var/cache/*.php`, which Symfony rewrites every request and would loop.

`make restart` (down + up) recreates the containers so the new worker config takes effect.