### PR TITLE
fix(docker): patch c-ares CVE-2026-33630 in the base image

### DIFF
--- a/docker/frankenphp/Dockerfile
+++ b/docker/frankenphp/Dockerfile
@@ -22,6 +22,12 @@ RUN apk add --no-cache \
 # bash for dev/* scripts run inside the container.
 RUN apk add --no-cache curl bash
 
+# Base-image CVE remediation: the frankenphp base ships c-ares 1.34.6-r0, which
+# carries CVE-2026-33630 (HIGH — use-after-free in query completion). Pull the
+# patched build so the prod-image Trivy gate stays green; drop this once the
+# base image ships c-ares >= 1.34.8-r0.
+RUN apk add --no-cache "c-ares>=1.34.8-r0"
+
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 ENV COMPOSER_MEMORY_LIMIT=-1
 


### PR DESCRIPTION
The frankenphp base image ships c-ares 1.34.6-r0, and the newly-disclosed CVE-2026-33630 (HIGH — use-after-free in query completion) trips the `prod-image` Trivy gate on every PR (also blocking #55 and #56).

Pin the patched `1.34.8-r0`, already available in the same Alpine 3.24 repo, until the base image catches up.